### PR TITLE
 Buffered channel for handshake notifications

### DIFF
--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -104,7 +104,7 @@ func New(settings *Settings) *StateMachine {
 	sm := &StateMachine{
 		cfg:           settings,
 		mux:           diam.NewServeMux(),
-		hsNotifyc:     make(chan diam.Conn, 20),
+		hsNotifyc:     make(chan diam.Conn, 100),
 		supportedApps: PrepareSupportedApps(settings.Dict),
 	}
 	sm.mux.Handle("CER", handleCER(sm))

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -104,7 +104,7 @@ func New(settings *Settings) *StateMachine {
 	sm := &StateMachine{
 		cfg:           settings,
 		mux:           diam.NewServeMux(),
-		hsNotifyc:     make(chan diam.Conn),
+		hsNotifyc:     make(chan diam.Conn, 20),
 		supportedApps: PrepareSupportedApps(settings.Dict),
 	}
 	sm.mux.Handle("CER", handleCER(sm))


### PR DESCRIPTION
ref https://github.com/fiorix/go-diameter/issues/180

this will reduce number of lost notifications due to busy channel reader

Ideally, it should also close a connection in case of failing:

// Notify about peer passing the handshake.
		select {
		case sm.hsNotifyc <- c:
		default:
		}
		
due to lack of experience with this code base, it is safer to keep buffer more or about number of pgw that will be connecting to voqos		